### PR TITLE
feat: normalized payee rejected requests handlers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10609,7 +10609,7 @@
         },
         "packages/account-lookup-svc": {
             "name": "@mojaloop/account-lookup-bc-account-lookup-svc",
-            "version": "0.5.4",
+            "version": "0.5.5",
             "license": "Apache-2.0",
             "dependencies": {
                 "@mojaloop/account-lookup-bc-domain-lib": "*",
@@ -10661,6 +10661,7 @@
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
+                "@mojaloop/account-lookup-bc-public-types-lib": "*",
                 "@mojaloop/logging-bc-public-types-lib": "~0.5.2",
                 "@mojaloop/participant-bc-public-types-lib": "~0.5.4",
                 "@mojaloop/platform-shared-lib-messaging-types-lib": "~0.5.4",
@@ -10730,7 +10731,7 @@
         },
         "packages/public-types-lib": {
             "name": "@mojaloop/account-lookup-bc-public-types-lib",
-            "version": "0.5.0",
+            "version": "0.5.2",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@types/node": "^20.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1488,9 +1488,9 @@
             }
         },
         "node_modules/@mojaloop/platform-shared-lib-public-messages-lib": {
-            "version": "0.5.15",
-            "resolved": "https://registry.npmjs.org/@mojaloop/platform-shared-lib-public-messages-lib/-/platform-shared-lib-public-messages-lib-0.5.15.tgz",
-            "integrity": "sha512-6I/hXZlMymwSgNNT1/IM6X/2McJmWpDNjyNwZD8VVsUuPSrgL4fY88XXTZ88AKTWJLOcjMMjM0qQJL0h0zk8gQ==",
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/@mojaloop/platform-shared-lib-public-messages-lib/-/platform-shared-lib-public-messages-lib-0.5.16.tgz",
+            "integrity": "sha512-zcGVrbxHR2q8Oo03N2ultUITZ32zN6uRRpBqQdxEua7OXs+cq4D0SP3tP+I5tDqU2u6VpxF/qlh9vSSKkrw6uA==",
             "dependencies": {
                 "@mojaloop/platform-shared-lib-messaging-types-lib": "~0.5.6"
             },
@@ -10621,7 +10621,7 @@
                 "@mojaloop/platform-shared-lib-nodejs-kafka-client-lib": "~0.5.11",
                 "@mojaloop/platform-shared-lib-observability-client-lib": "~0.5.1",
                 "@mojaloop/platform-shared-lib-observability-types-lib": "~0.5.2",
-                "@mojaloop/platform-shared-lib-public-messages-lib": "~0.5.15",
+                "@mojaloop/platform-shared-lib-public-messages-lib": "~0.5.16",
                 "@mojaloop/security-bc-client-lib": "~0.5.7",
                 "@mojaloop/security-bc-public-types-lib": "~0.5.5"
             },
@@ -10666,7 +10666,7 @@
                 "@mojaloop/participant-bc-public-types-lib": "~0.5.4",
                 "@mojaloop/platform-shared-lib-messaging-types-lib": "~0.5.4",
                 "@mojaloop/platform-shared-lib-observability-types-lib": "~0.5.2",
-                "@mojaloop/platform-shared-lib-public-messages-lib": "~0.5.15"
+                "@mojaloop/platform-shared-lib-public-messages-lib": "~0.5.16"
             },
             "devDependencies": {
                 "@mojaloop/account-lookup-bc-shared-mocks-lib": "*",

--- a/packages/account-lookup-svc/package.json
+++ b/packages/account-lookup-svc/package.json
@@ -43,7 +43,7 @@
         "@mojaloop/logging-bc-client-lib": "~0.5.2",
         "@mojaloop/logging-bc-public-types-lib": "~0.5.2",
         "@mojaloop/platform-shared-lib-messaging-types-lib": "~0.5.4",
-        "@mojaloop/platform-shared-lib-public-messages-lib": "~0.5.15",
+        "@mojaloop/platform-shared-lib-public-messages-lib": "~0.5.16",
         "@mojaloop/security-bc-client-lib": "~0.5.7",
         "@mojaloop/security-bc-public-types-lib": "~0.5.5",
         "@mojaloop/platform-shared-lib-observability-client-lib": "~0.5.1",

--- a/packages/domain-lib/package.json
+++ b/packages/domain-lib/package.json
@@ -37,7 +37,7 @@
         "@mojaloop/participant-bc-public-types-lib": "~0.5.4",
         "@mojaloop/logging-bc-public-types-lib": "~0.5.2",
         "@mojaloop/platform-shared-lib-messaging-types-lib": "~0.5.4",
-        "@mojaloop/platform-shared-lib-public-messages-lib": "~0.5.15",
+        "@mojaloop/platform-shared-lib-public-messages-lib": "~0.5.16",
         "@mojaloop/platform-shared-lib-observability-types-lib": "~0.5.2"
     },
     "devDependencies": {


### PR DESCRIPTION
Required changes to maintain the same error code structure across all BCs that communicate with the interop-api:

[#Issue 3465](https://app.zenhub.com/workspaces/mojaloop-project-59edee71d1407922110cf083/issues/gh/mojaloop/project/3465)