### PR TITLE
fix: null checks and length check for outputEvents to avoid unnecessary Kafka calls.

### DIFF
--- a/packages/account-lookup-svc/src/handler.ts
+++ b/packages/account-lookup-svc/src/handler.ts
@@ -139,8 +139,8 @@ export class AccountLookupEventHandler{
                     kind: SpanKind.CONSUMER,
                     attributes: {
                         "msgName": message.msgName,
-                        "entityId": message.payload.partyId,
-                        "partyId": message.payload.partyId,
+                        "entityId": message.payload?.partyId,
+                        "partyId": message.payload?.partyId,
                         "batchSize": receivedMessages.length
                     }
                 };
@@ -173,7 +173,7 @@ export class AccountLookupEventHandler{
             this._logger.error(errorMessage, error);
             throw error;
         }finally {
-            if (outputEvents) {
+            if (outputEvents.length > 0) {
                 const timerEndFn_kafkaSend = this._histo.startTimer({
                     callName: "handleAccountLookUpEventBatch - producer send",
                 });


### PR DESCRIPTION
while writing unit test for `_batchMsgHandler`, I found that it is sending empty outputEvents to kafka.